### PR TITLE
[swift3] Use baseName instead of paramName when generating query item…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/api.mustache
@@ -124,7 +124,7 @@ open class {{classname}}: APIBase {
         {{#hasQueryParams}}
         url?.queryItems = mapValuesToQueryItems(values:[
         {{#queryParams}}
-                "{{paramName}}": {{paramName}}{{#hasMore}}, {{/hasMore}}
+                "{{baseName}}": {{paramName}}{{#hasMore}}, {{/hasMore}}
         {{/queryParams}}
         ])
         {{/hasQueryParams}}


### PR DESCRIPTION
…s for a network request. Fixes issue where there is a difference between the two, for example 'param_name' and 'paramName'

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

